### PR TITLE
Fix tag in spruce_planks_from_hollowed.json

### DIFF
--- a/src/main/resources/data/wilderwild/recipes/spruce_planks_from_hollowed.json
+++ b/src/main/resources/data/wilderwild/recipes/spruce_planks_from_hollowed.json
@@ -4,7 +4,7 @@
   "group": "planks",
   "ingredients": [
     {
-      "tag": "wilderwild:spruce_hollowed_logs"
+      "tag": "wilderwild:hollowed_spruce_logs"
     }
   ],
   "result": {


### PR DESCRIPTION
This fixes the tag reference pointing to a non-existent tag due to a typing error.

![Comparison screenshot](https://github.com/ChloeDawn/WilderWild/assets/9869940/bb6acd29-fc6b-428f-8379-8822a6ce4335)
